### PR TITLE
Added Content-Type 'application/json' to the headers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@
       '-32603': 'Internal error'
     };
     function JsonrpcClient(endpoint) {
-      this.client = scopedClient.create(endpoint).header('Accept', 'application/json');
+      this.client = scopedClient.create(endpoint).header('Accept', 'application/json').header('Content-Type', 'application/json');
     }
     JsonrpcClient.prototype.call = function(method, params, callback) {
       var jsonParams, requestString;


### PR DESCRIPTION
it was not working when posting against a node-based json rpc server (connect-jsonrpc) without the content type.
